### PR TITLE
Convert Endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ FROM pelias/libpostal_baseimage
 LABEL maintainer="pelias@mapzen.com"
 
 EXPOSE 3100
-EXPOSE 3150
 
 # Where the app is built and run inside the docker fs
 ENV WORK=/opt/pelias
@@ -13,11 +12,24 @@ ENV WORK=/opt/pelias
 # Used indirectly for saving npm logs etc.
 ENV HOME=/opt/pelias
 
-# Update git submodules
-RUN git submodule update --init --recursive --remote
+#Set geotrans IP
+ENV GEOTRANS_IP=10.0.2.62
 
 WORKDIR ${WORK}
 COPY . ${WORK}
+
+# install required utilities
+RUN apt-get update && \
+    apt-get install -y vim curl
+
+# install node 6.x
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs
+
+# move original node and symlink
+RUN mv /usr/local/bin/node /usr/local/bin/node.original
+
+RUN ln -s /usr/bin/nodejs /usr/local/bin/node
 
 
 # Build and set permissions for arbitrary non-root user
@@ -25,19 +37,16 @@ RUN npm install && \
   npm test && \
   chmod -R a+rwX .
 
-
-
-# Compile GeoTrans
-RUN npm install --unsafe-perm geotrans-mgrs-converter
-# Install node-gyp for GeoTrans
-RUN npm install -g node-gyp
-# Configure and build NBIND for Geotrans node module
-RUN node-gyp configure build --directory=node_modules/geotrans-mgrs-converter/
-
 # Run geotrans env variable script
 #RUN . ./node_modules/geotrans-mgrs-converter/install.sh
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker.
 RUN chown -R 9999:9999 ${WORK}
 # USER 9999
+
+# start service
+CMD [ "npm", "start" ]
+
+
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # base image
-FROM pelias/baseimage
+FROM pelias/libpostal_baseimage
 
 # maintainer information
 LABEL maintainer="pelias@mapzen.com"
 
 EXPOSE 3100
+EXPOSE 3150
 
 # Where the app is built and run inside the docker fs
 ENV WORK=/opt/pelias
@@ -12,18 +13,31 @@ ENV WORK=/opt/pelias
 # Used indirectly for saving npm logs etc.
 ENV HOME=/opt/pelias
 
+# Update git submodules
+RUN git submodule update --init --recursive --remote
+
 WORKDIR ${WORK}
 COPY . ${WORK}
+
 
 # Build and set permissions for arbitrary non-root user
 RUN npm install && \
   npm test && \
   chmod -R a+rwX .
 
+
+
+# Compile GeoTrans
+RUN npm install --unsafe-perm geotrans-mgrs-converter
+# Install node-gyp for GeoTrans
+RUN npm install -g node-gyp
+# Configure and build NBIND for Geotrans node module
+RUN node-gyp configure build --directory=node_modules/geotrans-mgrs-converter/
+
+# Run geotrans env variable script
+#RUN . ./node_modules/geotrans-mgrs-converter/install.sh
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker.
 RUN chown -R 9999:9999 ${WORK}
-USER 9999
+# USER 9999
 
-# start service
-CMD [ "npm", "start" ]

--- a/controller/convert.js
+++ b/controller/convert.js
@@ -1,0 +1,43 @@
+"use strict";
+
+
+const _ = require('lodash');
+const DATUM = 'WGE';
+const external = require('../service/external');
+const logger = require( 'pelias-logger' ).get( 'api' );
+
+"use strict";
+
+
+
+function converter( req, res, next) {
+  let result;
+  try{
+    if(_.find(req.query, (val, key) => val === 'mgrs')){
+      //If mgrs is specified as a conversion parameter
+      //let mgrsConverter = new MGRS_converter(DATUM);
+      if(req.query.from === 'mgrs' && req.query.to === 'decdeg'){
+        logger.info("testing");
+        result = external.geotrans(req.query.q);
+        logger.info(result);
+      }
+    }
+    if(typeof result === 'string' && result.indexOf('ERROR') > -1){
+      //Relay error
+      throw result;
+    }
+    result.properties.from = req.query.from;
+    result.properties.to = req.query.to;
+    if(result.properties.name.toLowerCase() !== req.query.q.toLowerCase()){
+      result.properties.name = req.query.q.toUpperCase();
+    }
+  }
+  catch(error){
+    result = {"error": error};
+  }
+  finally{
+    res.send(result);
+  }
+}
+
+module.exports = converter;

--- a/controller/convert.js
+++ b/controller/convert.js
@@ -1,43 +1,37 @@
-"use strict";
-
+'use strict';
 
 const _ = require('lodash');
 const DATUM = 'WGE';
 const external = require('../service/external');
-const logger = require( 'pelias-logger' ).get( 'api' );
-
-"use strict";
-
 
 
 function converter( req, res, next) {
-  let result;
-  try{
     if(_.find(req.query, (val, key) => val === 'mgrs')){
-      //If mgrs is specified as a conversion parameter
-      //let mgrsConverter = new MGRS_converter(DATUM);
-      if(req.query.from === 'mgrs' && req.query.to === 'decdeg'){
-        logger.info("testing");
-        result = external.geotrans(req.query.q);
-        logger.info(result);
-      }
+        if(req.query.from === 'mgrs' && req.query.to === 'decdeg'){
+            try{
+                external.geotrans(req.query.q).then(function(gtResult){
+                    if(typeof gtResult === 'string' && gtResult.indexOf('ERROR') > -1){
+                        res.send(gtResult);
+                        throw gtResult;
+                    }
+                    else{
+                        res.send(addQueryProperties(gtResult, req.query));
+                    }
+                }).catch(function(error){
+                    res.send({'error':error});
+                });
+            }
+            catch(error){
+                res.send({'error': error});
+            }
+        }
     }
-    if(typeof result === 'string' && result.indexOf('ERROR') > -1){
-      //Relay error
-      throw result;
-    }
-    result.properties.from = req.query.from;
-    result.properties.to = req.query.to;
-    if(result.properties.name.toLowerCase() !== req.query.q.toLowerCase()){
-      result.properties.name = req.query.q.toUpperCase();
-    }
-  }
-  catch(error){
-    result = {"error": error};
-  }
-  finally{
-    res.send(result);
-  }
+}
+
+function addQueryProperties (geojson, query){
+    geojson.properties.from = query.from;
+    geojson.properties.to = query.to;
+    return geojson;
 }
 
 module.exports = converter;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "predicates": "^2.0.0",
     "retry": "^0.10.1",
     "stats-lite": "^2.0.4",
-    "through2": "^2.0.3"
+    "through2": "^2.0.3",
+    "axios": "^0.17.1"
   },
   "devDependencies": {
     "ciao": "^1.0.0",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -29,6 +29,7 @@ var controllers = {
   coarse_reverse: require('../controller/coarse_reverse'),
   mdToHTML: require('../controller/markdownToHtml'),
   libpostal: require('../controller/libpostal'),
+  structured_libpostal: require('../controller/structured_libpostal'),
   place: require('../controller/place'),
   placeholder: require('../controller/placeholder'),
   search: require('../controller/search'),
@@ -97,6 +98,7 @@ const PlaceHolder = require('../service/configurations/PlaceHolder');
 const PointInPolygon = require('../service/configurations/PointInPolygon');
 const Language = require('../service/configurations/Language');
 const Interpolation = require('../service/configurations/Interpolation');
+const Libpostal = require('../service/configurations/Libpostal');
 
 /**
  * Append routes to app
@@ -123,6 +125,18 @@ function addRoutes(app, peliasConfig) {
   const interpolationService = serviceWrapper(interpolationConfiguration);
   const isInterpolationEnabled = _.constant(interpolationConfiguration.isEnabled());
 
+  // standard libpostal should use req.clean.text for the `address` parameter
+  const libpostalConfiguration = new Libpostal(
+    _.defaultTo(peliasConfig.api.services.libpostal, {}),
+    _.property('clean.text'));
+  const libpostalService = serviceWrapper(libpostalConfiguration);
+
+  // structured libpostal should use req.clean.parsed_text.address for the `address` parameter
+  const structuredLibpostalConfiguration = new Libpostal(
+    _.defaultTo(peliasConfig.api.services.libpostal, {}),
+    _.property('clean.parsed_text.address'));
+  const structuredLibpostalService = serviceWrapper(structuredLibpostalConfiguration);
+
   // fallback to coarse reverse when regular reverse didn't return anything
   const coarseReverseShouldExecute = all(
     isPipServiceEnabled, not(hasRequestErrors), not(hasResponseData)
@@ -131,6 +145,12 @@ function addRoutes(app, peliasConfig) {
   const libpostalShouldExecute = all(
     not(hasRequestErrors),
     not(isRequestSourcesOnlyWhosOnFirst)
+  );
+
+  // for libpostal to execute for structured requests, req.clean.parsed_text.address must exist
+  const structuredLibpostalShouldExecute = all(
+    not(hasRequestErrors),
+    hasParsedTextProperties.all('address')
   );
 
   // execute placeholder if libpostal only parsed as admin-only and needs to
@@ -257,7 +277,7 @@ function addRoutes(app, peliasConfig) {
       sanitizers.search.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.calcSize(),
-      controllers.libpostal(libpostalShouldExecute),
+      controllers.libpostal(libpostalService, libpostalShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersDontApply, placeholderIdsLookupShouldExecute),
       controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
@@ -287,6 +307,7 @@ function addRoutes(app, peliasConfig) {
       sanitizers.structured_geocoding.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.calcSize(),
+      controllers.structured_libpostal(structuredLibpostalService, structuredLibpostalShouldExecute),
       controllers.search(peliasConfig.api, esclient, queries.structured_geocoding, not(hasResponseDataOrRequestErrors)),
       postProc.trimByGranularityStructured(),
       postProc.distances('focus.point.'),

--- a/service/external.js
+++ b/service/external.js
@@ -1,18 +1,23 @@
-const request = require('request');
-const logger = require('pelias-logger').get('api');
-
 "use strict";
 
-async function geotrans(coord) { 
-    let result;
-    request(`http://10.0.2.62:3150?datum=WGE&coord=${coord}`, function (error, response, body) {
-        logger.info(response.body);
-        result = response.body;
-    });
-    return result;
-    
-}
+const axios = require('axios');
+const geotransIP = process.env.GEOTRANS_IP;
 
+function geotrans(coord) { 
+    let result;
+    return axios.get(`http://${geotransIP}:3150`, {
+        params:{
+            'datum':'WGE',
+            'coord':coord
+        }
+    })
+    .then(function (response){
+        return response.data;
+    }).catch(function (reason){
+        return reason;
+    });
+}
+  
 module.exports = {
     geotrans: geotrans
 };

--- a/service/external.js
+++ b/service/external.js
@@ -1,19 +1,25 @@
 "use strict";
 
+const logger = require( 'pelias-logger' ).get( 'api' );
 const axios = require('axios');
 const geotransIP = process.env.GEOTRANS_IP;
 
 function geotrans(coord) { 
-    let result;
-    return axios.get(`http://${geotransIP}:3150`, {
+    let url = `http://${geotransIP}:3150`;
+    logger.info(`GET ${url}`);
+    return axios.get(url, {
         params:{
             'datum':'WGE',
             'coord':coord
         }
     })
     .then(function (response){
+        logger.info('200');
+        logger.info(response.data);
         return response.data;
     }).catch(function (reason){
+        logger.info('ERROR');
+        logger.info(reason);
         return reason;
     });
 }

--- a/service/external.js
+++ b/service/external.js
@@ -1,0 +1,18 @@
+const request = require('request');
+const logger = require('pelias-logger').get('api');
+
+"use strict";
+
+async function geotrans(coord) { 
+    let result;
+    request(`http://10.0.2.62:3150?datum=WGE&coord=${coord}`, function (error, response, body) {
+        logger.info(response.body);
+        result = response.body;
+    });
+    return result;
+    
+}
+
+module.exports = {
+    geotrans: geotrans
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -105,7 +105,8 @@ var tests = [
   require('./service/configurations/PlaceHolder'),
   require('./service/configurations/PointInPolygon'),
   require('./service/mget'),
-  require('./service/search')
+  require('./service/search'),
+  require('./service/external')
 ];
 
 tests.map(function(t) {

--- a/test/unit/service/external.js
+++ b/test/unit/service/external.js
@@ -34,7 +34,7 @@ module.exports.tests.functionality = (test, common) => {
       });
       
     });
-    /*test('error thrown', (t) => {
+    test('response received', (t) => {
       var service = proxyquire('../../../service/external', {
         'logger': {
           get: (section) => {
@@ -44,12 +44,12 @@ module.exports.tests.functionality = (test, common) => {
       });
 
       service.geotrans('18TXM9963493438').then(function(response){
-        
-        t.equal(response, { 'type': 'Feature', 'geometry': { 'type': 'Point', 'coordinates': [ -72.57553258519015, 42.367593344066776 ] }, 'properties': { 'name': '18TXM9963493438' } }, 'Geotrans conversion succeeds and properties are added');
+        let res = { 'type': 'Feature', 'geometry': { 'type': 'Point', 'coordinates': [ -72.57553258519015, 42.367593344066776 ] }, 'properties': { 'name': '18TXM9963493438' } };
+        t.equal(response.toString(), res.toString(), 'Geotrans conversion succeeds and properties are added');
         t.end();
       });
       
-    });*/
+    });
   };
 
 module.exports.all = (tape, common) => {

--- a/test/unit/service/external.js
+++ b/test/unit/service/external.js
@@ -1,0 +1,65 @@
+const proxyquire = require('proxyquire').noCallThru();
+
+module.exports.tests = {};
+
+module.exports.tests.interface = (test, common) => {
+  test('valid interface', (t) => {
+    var service = proxyquire('../../../service/external', {
+      'pelias-logger': {
+        get: (section) => {
+          t.equal(section, 'api');
+        }
+      }
+
+    });
+
+    t.equal(typeof service, 'object', 'service is a object');
+    t.equal(typeof service.geotrans, 'function', 'geotrans is a function');
+    t.end();
+  });
+};
+
+module.exports.tests.functionality = (test, common) => {
+    test('error thrown', (t) => {
+      var service = proxyquire('../../../service/external', {
+        'logger': {
+          get: (section) => {
+            t.equal(section, 'api');
+          }
+        }
+      });
+      service.geotrans('4CFG').then(function(response){
+        t.equal(response, 'ERROR: Invalid MGRS String', 'Geotrans conversion throws error when an invalid coordinate is given');
+        t.end();
+      });
+      
+    });
+    /*test('error thrown', (t) => {
+      var service = proxyquire('../../../service/external', {
+        'logger': {
+          get: (section) => {
+            t.equal(section, 'api');
+          }
+        }
+      });
+
+      service.geotrans('18TXM9963493438').then(function(response){
+        
+        t.equal(response, { 'type': 'Feature', 'geometry': { 'type': 'Point', 'coordinates': [ -72.57553258519015, 42.367593344066776 ] }, 'properties': { 'name': '18TXM9963493438' } }, 'Geotrans conversion succeeds and properties are added');
+        t.end();
+      });
+      
+    });*/
+  };
+
+module.exports.all = (tape, common) => {
+    
+      function test(name, testFunction) {
+        return tape('SERVICE /external ' + name, testFunction);
+      }
+    
+      for( var testCase in module.exports.tests ){
+        module.exports.tests[testCase](test, common);
+      }
+    };
+    


### PR DESCRIPTION
`/v1/convert` endpoint accepts the following REST parameters:

`from`: Origin coordinate type. Currently only `mgrs` is supported .
`to`: Destination coordinate type. Currently only `decdeg` is supported. Converts origin to geodetic coordinates in WGS84 datum.
`q`: Coordinate itself.

This endpoint acts as a proxy for the [Geotrans MGRS Converter](https://github.com/venicegeo/geotrans-mgrs-converter) Docker container serving at port 3150.

![image](https://user-images.githubusercontent.com/32872347/34961890-4547b3ea-fa0f-11e7-8252-12e6ab6e0ed6.png)

**Instructions to test:**
1. Run [Geotrans MGRS Converter](https://github.com/venicegeo/geotrans-mgrs-converter) dockerfile. Ensure that converter is being server at port 3150.
2. Run this Pelias API. Test converter with `from`, `to`, and `q` parameters populated.
