### PR TITLE
GEOTRANS_PORT Environment Variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ ENV WORK=/opt/pelias
 ENV HOME=/opt/pelias
 
 #Set geotrans IP
-ENV GEOTRANS_IP=
-ENV GEOTRANS_PORT=
+ENV GEOTRANS_URL=
 
 WORKDIR ${WORK}
 COPY . ${WORK}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV HOME=/opt/pelias
 
 #Set geotrans IP
 ENV GEOTRANS_IP=
+ENV GEOTRANS_PORT=
 
 WORKDIR ${WORK}
 COPY . ${WORK}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 Note: This is required for use of the `convert` endpoint.
 [See VeniceGeo Repo](https://github.com/venicegeo/geotrans-mgrs-converter)
 
-Once you have the GeoTrans container running, you will need to set the `ENV GEOTRANS_IP` and `ENV GEOTRANS_PORT` in this repository's docker file.
+Once you have the GeoTrans container running, you will need to set the `ENV GEOTRANS_URL` in this repository's docker file.
 You can set these to your host:port or the GeoTrans container's IP and port at which it is exposed.
 
 ## Build and run Pelias-API alone

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ npm install
 Note: This is required for use of the `convert` endpoint.
 [See VeniceGeo Repo](https://github.com/venicegeo/geotrans-mgrs-converter)
 
-Once you have the GeoTrans container running, you will need to set the `ENV GEOTRANS_IP` in this repository's docker file.
-You can set this to your host (as long as port 3150 is exposed) or the GeoTrans container's IP.
+Once you have the GeoTrans container running, you will need to set the `ENV GEOTRANS_IP` and `ENV GEOTRANS_PORT` in this repository's docker file.
+You can set these to your host:port or the GeoTrans container's IP and port at which it is exposed.
 
 ## Build and run Pelias-API alone
 

--- a/service/external.js
+++ b/service/external.js
@@ -3,7 +3,7 @@
 const logger = require( 'pelias-logger' ).get( 'api' );
 const axios = require('axios');
 const geotransIP = process.env.GEOTRANS_IP;
-const geotransPort = process.env.GEOTRANS_PORT;
+const geotransPort = process.env.GEOTRANS_PORT||3000;
 
 function geotrans(coord) { 
     let url = `http://${geotransIP}:${geotransPort}`;

--- a/service/external.js
+++ b/service/external.js
@@ -3,9 +3,10 @@
 const logger = require( 'pelias-logger' ).get( 'api' );
 const axios = require('axios');
 const geotransIP = process.env.GEOTRANS_IP;
+const geotransPort = process.env.GEOTRANS_PORT;
 
 function geotrans(coord) { 
-    let url = `http://${geotransIP}:3150`;
+    let url = `http://${geotransIP}:${geotransPort}`;
     logger.info(`GET ${url}`);
     return axios.get(url, {
         params:{

--- a/service/external.js
+++ b/service/external.js
@@ -2,11 +2,10 @@
 
 const logger = require( 'pelias-logger' ).get( 'api' );
 const axios = require('axios');
-const geotransIP = process.env.GEOTRANS_IP;
-const geotransPort = process.env.GEOTRANS_PORT||3000;
+const geotransURL = process.env.GEOTRANS_URL;
 
 function geotrans(coord) { 
-    let url = `http://${geotransIP}:${geotransPort}`;
+    let url = geotransURL;
     logger.info(`GET ${url}`);
     return axios.get(url, {
         params:{


### PR DESCRIPTION
Allows port to be whatever you set it to in container's environment variable, otherwise default to 3000 as per PCF guidelines.