### PR TITLE
Update documentation link on landing page

### DIFF
--- a/controller/markdownToHtml.js
+++ b/controller/markdownToHtml.js
@@ -6,7 +6,7 @@ function setup(peliasConfig, markdownFile){
 
   var styleString = '<style>html{font-family:monospace}</style>';
   var text = '# Pelias API\n';
-  text += '### Version: [' + peliasConfig.version + '](https://github.com/pelias/api/releases)\n';
+  text += '### Version: [' + peliasConfig.version + '](https://github.com/venicegeo/pelias-api/releases)\n';
   text += fs.readFileSync( markdownFile, 'utf8');
   var html = styleString + markdown.toHTML(text);
 

--- a/public/apiDoc.md
+++ b/public/apiDoc.md
@@ -1,1 +1,1 @@
-## [View our documentation on GitHub](https://github.com/pelias/pelias-doc/blob/master/index.md)
+## [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/32872347/37912656-fa461838-30e0-11e8-9e5e-58fdc6fd75d1.png)


Now points to `https://github.com/venicegeo/pelias-documentation/blob/master/README.md`
