### PR TITLE
Parse geometries parameter for valid types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,15 +34,15 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node
 
 # Build and set permissions for arbitrary non-root user
 RUN npm install && \
-  #npm test && \
+  npm test && \
   chmod -R a+rwX .
 
 # Run geotrans env variable script
 #RUN . ./node_modules/geotrans-mgrs-converter/install.sh
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker.
-# RUN chown -R 9999:9999 ${WORK}
-# USER 9999
+ RUN chown -R 9999:9999 ${WORK}
+ USER 9999
 
 # start service
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,15 +34,15 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node
 
 # Build and set permissions for arbitrary non-root user
 RUN npm install && \
-  npm test && \
+  #npm test && \
   chmod -R a+rwX .
 
 # Run geotrans env variable script
 #RUN . ./node_modules/geotrans-mgrs-converter/install.sh
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker.
-RUN chown -R 9999:9999 ${WORK}
-USER 9999
+# RUN chown -R 9999:9999 ${WORK}
+# USER 9999
 
 # start service
 CMD [ "npm", "start" ]

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -9,7 +9,6 @@ function geojsonifyPlaces(params, docs, geometriesParam, errors){
 
   // Parse geometries param for valid types
   let requestedGeometries = geometriesParam ? parseGeometries(geometriesParam, errors) : ['point'];
-  console.log(requestedGeometries);
   // Weed out non-geo data.
   const geodata = docs.filter(doc => !!_.has(doc, 'center_point'));
   

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -6,13 +6,8 @@ const _ = require('lodash');
 const Document = require('pelias-model').Document;
 
 function geojsonifyPlaces(params, docs, geometriesParam){
-  let requestedGeometries;
-  if(geometriesParam){
-    requestedGeometries = geometriesParam.split(',');
-  }
-  else{
-    requestedGeometries = ['point'];
-  }
+  // Parse geometries param for valid types
+  let requestedGeometries = parseGeometries(geometriesParam) || ['point'];
   // Weed out non-geo data.
   const geodata = docs.filter(doc => !!_.has(doc, 'center_point'));
   
@@ -199,6 +194,20 @@ function computeBBox(geojson, geojsonExtentPoints) {
   } catch( e ){
     console.error( 'bbox error', e.message, e.stack );
     console.error( 'geojson', JSON.stringify( geojsonExtentPoints, null, 2 ) );
+  }
+}
+
+/**
+ * Check that geometries parameter includes at least one valid geometry type if specified at all.
+ * Otherwise default to point data.
+ * @param {string} geometriesParam parameter to split and compare to valid types array.
+ * @returns {boolean} Whether there is at least one valid type in the parameter or not.
+ */
+function parseGeometries(geometriesParam){
+  if(geometriesParam){
+   const validTypes = ['point','polygon'];
+   const requestedGeometries = geometriesParam.split(',');
+   return requestedGeometries.some(r=> validTypes.includes(r)) ? requestedGeometries : false;
   }
 }
 

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -5,9 +5,11 @@ const collectDetails = require('./geojsonify_place_details');
 const _ = require('lodash');
 const Document = require('pelias-model').Document;
 
-function geojsonifyPlaces(params, docs, geometriesParam){
+function geojsonifyPlaces(params, docs, geometriesParam, errors){
+
   // Parse geometries param for valid types
-  let requestedGeometries = parseGeometries(geometriesParam) || ['point'];
+  let requestedGeometries = geometriesParam ? parseGeometries(geometriesParam, errors) : ['point'];
+  console.log(requestedGeometries);
   // Weed out non-geo data.
   const geodata = docs.filter(doc => !!_.has(doc, 'center_point'));
   
@@ -201,14 +203,20 @@ function computeBBox(geojson, geojsonExtentPoints) {
  * Check that geometries parameter includes at least one valid geometry type if specified at all.
  * Otherwise default to point data.
  * @param {string} geometriesParam parameter to split and compare to valid types array.
+ * @param {array} errorList list of errors to be displayed on geocoding result.
  * @returns {boolean} Whether there is at least one valid type in the parameter or not.
  */
-function parseGeometries(geometriesParam){
-  if(geometriesParam){
-   const validTypes = ['point','polygon'];
-   const requestedGeometries = geometriesParam.split(',');
-   return requestedGeometries.some(r=> validTypes.includes(r)) ? requestedGeometries : false;
-  }
+function parseGeometries(geometriesParam, errorList){
+    const validTypes = ['point','polygon'];
+    const requestedGeometries = geometriesParam.split(',');
+    let invalid = 0;
+    requestedGeometries.forEach( entry => { 
+      if(validTypes.indexOf(entry) === -1){
+        errorList.push(entry + ' is not a valid geometry type');
+        invalid++;
+      }
+    });
+    return invalid < requestedGeometries.length ? requestedGeometries : false;
 }
 
 module.exports = geojsonifyPlaces;

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -75,12 +75,12 @@ function convertToGeocodeJSON(req, res, next, opts) {
   let geometries = req.query.geometries || undefined;
   
   // create errors array 
-  res.body.geocoding.errors = [];
-  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.warnings || []));
+  res.body.geocoding.warnings = [];
+  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.warnings));
 
   // remove empty array if necessary
-  if(!res.body.geocoding.errors.length){
-    delete res.body.geocoding.errors;
+  if(!res.body.geocoding.warnings.length){
+    delete res.body.geocoding.warnings;
   }
 
   next();

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -73,7 +73,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
 
   // convert docs to geojson and merge with geocoding block
   let geometries = req.query.geometries || undefined;
-  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries));
+  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.errors || []));
 
   next();
 }

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -73,7 +73,15 @@ function convertToGeocodeJSON(req, res, next, opts) {
 
   // convert docs to geojson and merge with geocoding block
   let geometries = req.query.geometries || undefined;
+  
+  // create errors array 
+  res.body.geocoding.errors = [];
   _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.errors || []));
+
+  // remove empty array if necessary
+  if(!res.body.geocoding.errors.length){
+    delete res.body.geocoding.errors;
+  }
 
   next();
 }

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -76,7 +76,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
   
   // create errors array 
   res.body.geocoding.errors = [];
-  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.errors || []));
+  _.extend(res.body, geojsonify(req.clean, res.data || [], geometries, res.body.geocoding.warnings || []));
 
   // remove empty array if necessary
   if(!res.body.geocoding.errors.length){

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "predicates": "^2.0.0",
     "retry": "^0.10.1",
     "stats-lite": "^2.0.4",
-    "swagger-ui-express": "^3.0.9",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,15 +38,16 @@
     "node": ">=6.12.3 <9.0.0"
   },
   "dependencies": {
+    "@mapbox/geojson-extent": "^0.3.1",
     "addressit": "1.5.0",
     "async": "^2.0.0",
+    "axios": "^0.17.1",
     "check-types": "^7.0.0",
     "elasticsearch": "^13.0.0",
     "elasticsearch-exceptions": "0.0.4",
     "express": "^4.8.8",
     "express-jwt": "^0.3.1",
     "geojson": "^0.5.0",
-    "@mapbox/geojson-extent": "^0.3.1",
     "geolib": "^2.0.18",
     "iso-639-3": "^1.0.0",
     "iso3166-1": "^0.3.0",
@@ -67,8 +68,8 @@
     "predicates": "^2.0.0",
     "retry": "^0.10.1",
     "stats-lite": "^2.0.4",
-    "through2": "^2.0.3",
-    "axios": "^0.17.1"
+    "swagger-ui-express": "^3.0.9",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "ciao": "^1.0.0",

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -7,7 +7,7 @@ module.exports.tests = {};
 module.exports.tests.interface = function(test, common) {
   test('valid interface', function(t) {
     t.equal(typeof geojsonify, 'function', 'geojsonify is a function');
-    t.equal(geojsonify.length, 3, 'accepts x arguments');
+    t.equal(geojsonify.length, 4, 'accepts x arguments');
     t.end();
   });
 };
@@ -576,93 +576,7 @@ module.exports.tests.non_optimal_conditions = (test, common) => {
 };
 
  module.exports.tests.polygons = (test, common) => {
-//   test('polygon should be interpreted as such, and not point', t => {
-//     const logger = require('pelias-mock-logger')();
-//     let coords = [
-//       [
-//           [100.0, 0.0],
-//           [101.0, 0.0],
-//           [101.0, 1.0],
-//           [100.0, 1.0],
-//           [100.0, 0.0]
-//       ],
-//       [
-//           [100.8, 0.8],
-//           [100.8, 0.2],
-//           [100.2, 0.2],
-//           [100.2, 0.8],
-//           [100.8, 0.8]
-//       ]
-//   ];
-//     const input = [
-//       {
-//         _id: 'id 1',
-//         source: 'source 1',
-//         source_id: 'source_id 1',
-//         layer: 'layer 1',
-//         name: {
-//           default: 'name 1',
-//         },
-//         center_point: {
-//           lat: 12.121212,
-//           lon: 21.212121
-//         },
-//         polygon: {
-//             type: 'MultiPolygon',
-//             coordinates: coords
-//         },
-//         bounding_box: {
-//           min_lon: 0,
-//           max_lon: 1,
-//           min_lat: 0,
-//           max_lat: 1
-//         }
-//       }
-//     ];
 
-//     const geojsonify = proxyquire('../../../helper/geojsonify', {
-//       './geojsonify_place_details': (params, source, dst) => {
-//         if (source._id === 'id 1') {
-//           return {
-//             property1: 'property 1',
-//             property2: 'property 2'
-//           };
-//         }
-//       },
-//       'pelias-logger': logger
-//     });
-
-//     const actual = geojsonify({}, input, 'point,polygon');
-
-//     const expected = {
-//       type: 'FeatureCollection',
-//       features: [
-//         {
-//           type: 'Feature',
-//           geometry: {
-//             type: 'Polygon',
-//             coordinates: coords
-//           },
-//           properties: {
-//             id: 'id 1',
-//             gid: 'source 1:layer 1:id 1',
-//             layer: 'layer 1',
-//             source: 'source 1',
-//             source_id: 'source_id 1',
-//             name: 'name 1',
-//             property1: 'property 1',
-//             property2: 'property 2'
-//           },
-//           bbox: [0,0,1,1]
-//         }
-//       ],
-//       bbox: [0,0,1,1]
-//     };
-
-//     t.deepEquals(actual, expected);
-//     t.end();
-
-//   });
   test('polygon should be not be interpreted as polygon if the parameter is not specified', t => {
     const logger = require('pelias-mock-logger')();
 
@@ -743,6 +657,18 @@ module.exports.tests.non_optimal_conditions = (test, common) => {
     t.deepEquals(actual, expected);
     t.end();
 
+  });
+  test('errors should be populated if a geometry type is invalid', t => {
+    const logger = require('pelias-mock-logger')();
+    const geojsonify = proxyquire('../../../helper/geojsonify', {
+      'pelias-logger': logger
+    });
+    let errorList = [];
+    geojsonify({}, [], 'point,polgon', errorList);
+    const expected = ['polgon is not a valid geometry type'];
+  
+    t.deepEquals(errorList, expected);
+    t.end();
   });
 
 };


### PR DESCRIPTION
Check is the geometries parameter contains valid geometry types. If there is not at least one valid type, then geometries are defaulted to `point` type only.

If an invalid parameter is specified, then the geocoding result body will add `{entry} is not a valid geometry type`.

i.e.

```javascript
// 20180518102744
// http://localhost:3100/v1/search?text=portland&geometries=polygon,piont

{
  "geocoding": {
    "version": "0.2",
    "attribution": "http://pelias.mapzen.com/v1/attribution",
    "query": {
      "text": "portland",
      "size": 10,
      "private": false,
      "lang": {
        "name": "English",
        "iso6391": "en",
        "iso6393": "eng",
        "defaulted": false
      },
      "querySize": 20
    },
    "warnings": [
      "piont is not a valid geometry type"
    ],
    "engine": {
      "name": "Pelias",
      "author": "Mapzen",
      "version": "1.0"
    },
    "timestamp": 1526653664314
  },
  "type": "FeatureCollection",
  "features": [
    
  ]
}
```