### PR TITLE
Res.send data rather than promise

### DIFF
--- a/controller/convert.js
+++ b/controller/convert.js
@@ -8,7 +8,7 @@ const external = require('../service/external');
 function converter( req, res, next) {
     try{
         external.geotrans(req.query).then(function(gtResult){
-            res.send(addQueryProperties(gtResult, req.query));
+            res.send(addQueryProperties(gtResult.data, req.query));
         }).catch(function(error){
             if(error.response){
                 res.send(error.response.data);


### PR DESCRIPTION
Was using promise for adding `from` and `to` parameters, causing successful geotrans calls to hang.