### PR TITLE
List of authorized distinguished names for GeoAXIS JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The API recognizes the following properties under the top-level `api` key in you
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`services`|*no*||service definitions for [point-in-polygon](https://github.com/pelias/pip-service), and [placeholder](https://github.com/pelias/placeholder), and [interpolation](https://github.com/pelias/interpolation) services.  If missing (which is not recommended), the services will not be called.|
-|`defaultParameters.focus.point.lon` <br> `defaultParameters.focus.point.lat`|no | |default coordinates for focus point
+|`defaultParameters.focus.point.lon` <br> `defaultParameters.focus.point.lat`|*no*| |default coordinates for focus point|
+|`auth`|*no*|false|Enables authentication for Pelias API access. Currently, only GeoAXIS JWTs are supported - set to `"geoaxis_jwt"`. |
 
 Example configuration file would look something like this:
 
@@ -105,7 +106,8 @@ Example configuration file would look something like this:
     "defaultParameters": {
       "focus.point.lat": 12.121212,
       "focus.point.lon": 21.212121
-    }
+    },
+    "auth": "geoaxis_jwt"
   },
   "logger": {
     "level": "debug"

--- a/service/auth.js
+++ b/service/auth.js
@@ -20,11 +20,13 @@ function determineAuth() {
       return (req, res, done) => {
         if(req.header('Authorization')){
           let jwtPayload = jwt.decode(req.header('Authorization').split(' ')[1]);
-          if(process.env.GEOAXIS_DN.split(';').indexOf(jwtPayload.dn) !== -1 && checkTime(jwtPayload.exp)){
-            done();
-          }
-          else if(!checkTime(jwtPayload.exp)){
-            res.status(401).send({ error: 'Expired token' });
+          if (jwtPayload){
+            if(process.env.GEOAXIS_DN.split(';').indexOf(jwtPayload.dn) !== -1 && checkTime(jwtPayload.exp)){
+              done();
+            }
+            else if(!checkTime(jwtPayload.exp)){
+              res.status(401).send({ error: 'Expired token' });
+            }
           }
           else {
             res.status(401).send({ error: 'Invalid token' });
@@ -33,7 +35,6 @@ function determineAuth() {
         else{
           res.status(401).send({ error: 'Missing token' });
         }
-        let jwtPayload = jwt.decode(req.header('Authorization').split(' ')[1]);
         
       };
     }

--- a/service/auth.js
+++ b/service/auth.js
@@ -20,7 +20,7 @@ function determineAuth() {
       return (req, res, done) => {
         if(req.header('Authorization')){
           let jwtPayload = jwt.decode(req.header('Authorization').split(' ')[1]);
-          if(jwtPayload.dn === process.env.GEOAXIS_DN && checkTime(jwtPayload.exp)){
+          if(process.env.GEOAXIS_DN.split(';').indexOf(jwtPayload.dn) !== -1 && checkTime(jwtPayload.exp)){
             done();
           }
           else if(!checkTime(jwtPayload.exp)){

--- a/test/unit/service/auth.js
+++ b/test/unit/service/auth.js
@@ -57,8 +57,37 @@ module.exports.tests.functionality = (test, common) => {
       t.equal(service.determineAuth()(req, undefined,(error)=>{return error;}, null).name,'UnauthorizedError');
       t.end();
     });
+    test('verify distinguished name if geoaxis_jwt set', (t) => {
+      let jwtUser1 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkbiI6InVzZXIxIiwianRpIjoiYzJjZjJiODQtMTU3Ny00ODVjLTkxNGMtMTZhMzI5Y2RhZTU4IiwiaWF0IjoxNTI2OTI5Mjc0LCJleHAiOjE1MjY5MzI4NzR9.otW671EC_0HmPIw_JvIhyEOBJ5JrA9I-brtMCM4K0FA';
+      let jwtUser2 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJkbiI6InVzZXIyIiwianRpIjoiMGUyYzM0ZGYtNzA3ZS00NDdjLWI5ZjUtNTNjNTdmNmEwOTdmIiwiaWF0IjoxNTI2OTI5Mjk4LCJleHAiOjE1MjY5MzI4OTh9.bhW2Ql4Y9W9LJTf9XMa5Vx3V65Rnus7SA5teD14f5Us';
+      let req = { 
+        'method':'OPTIONS',
+        'header': (k) => {
+          return 'Bearer ' + jwtUser1;
+        }
+      };
+      process.env.GEOAXIS_DN = 'user1;user2';
+      var service = proxyquire('../../../service/auth', {
+        'pelias-logger': {
+          get: (section) => {
+            t.equal(section, 'api');
+          }
+        },
+        'pelias-config': {
+          generate: () => {
+              return {
+                  'api': {
+                      'auth':'geoaxis_jwt'
+                  }
+              };
+          }
+        }
+      });                                           
+      t.equal(service.determineAuth()(req, undefined,(error)=>{return error;}, null).name,'UnauthorizedError');
+      t.end();
+    });
   };
-
+  
 module.exports.all = (tape, common) => {
     
       function test(name, testFunction) {


### PR DESCRIPTION
This PR allows for the environmental variable `GEOAXIS_DN` to be set to a list of names separated by semi-colons (or one name with no semi-colon). Any distinguished name included in a JWT included in this whitelist to use any backend endpoints locked behind the auth service.

**In a full dockerfiles environment:** 
In the `docker-compose.yml` under the `api` hierarchy, one can set the `GEOAXIS_DN` environmental variable in an `environment: [ ...]` key or using a separate file whos path is specified by `env_file`.

**In a standalone pelias_api container:** 
Simply set `ENV GEOAXIS_DN=user1;user2` (where 1 and 2 are whatever names you choose) in the Dockerfile.

To generate JWTs with _user1_ and _user2_, you can use [jwtbuilder.jamiekurtz.com](jwtbuilder.jamiekurtz.com) or use the ones I have created below:

**user1, expires 05-23-2027:**
```
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MjcwOTE2NzAsImV4cCI6MTcxNjQ4MDQ3MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImRuIjoidXNlcjIifQ.FRPMlXy355TLn93TSo5Ga9tie-yOH7FnIR3JgfakPHU
```
**user2, expires 05-23-2027**
```
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MjcwOTE2NzAsImV4cCI6MTcxNjQ4MDQ3MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImRuIjoidXNlcjEifQ.t5WUdD-TbWYj4O0RmfZ6cZBnKxWw2ea1GU-P9_x25FA
```

To test with the a JWT returned by the GeoAXIS JWT service, you must simply set one of the entries in `GEOAXIS_DN`  (again, separated by `;`) to `cn=geoaxis_test_1,ou=component,ou=nga,ou=dod,o=u.s. government,c=us`

As for passing a JWT on a request, you can find some instructions [here](https://jwt.io/introduction/). I recommend using [Postman desktop version](https://www.getpostman.com/apps) and attaching the JWT in the convenient request header UI.