### PR TITLE
Auto-generated Swagger 2.0 Documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,37 @@
 const app = require('express')();
 const jwt = require('jsonwebtoken');
-
+const swaggerJSDoc = require('swagger-jsdoc');
+const swaggerUi = require('express-swaggerize-ui');    
 const peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
 
 if( peliasConfig.api.accessLog ){
   app.use( require( './middleware/access_log' ).createAccessLogger( peliasConfig.api.accessLog ) );
 }
 
+var swaggerDefinition = {
+  info: { // API informations (required)
+    title: 'Hello World', // Title (required)
+    version: '1.0.0', // Version (required)
+    description: 'A sample API', // Description (optional)
+  },
+  basePath: __dirname, // Base path (optional)
+};
+var options = {
+  // Import swaggerDefinitions
+  swaggerDefinition: swaggerDefinition,
+  // Path to the API docs
+  apis: ['routes/*.js']
+};
+var swaggerSpec = swaggerJSDoc(options);
+
+
+
+app.get('/api-docs.json', function(req, res) {
+  res.setHeader('Content-Type', 'application/json');
+  res.send(swaggerSpec);
+});
+
+app.use('/api-docs', swaggerUi());
 /** ----------------------- pre-processing-middleware ----------------------- **/
 
 app.use( require('./middleware/headers') );

--- a/app.js
+++ b/app.js
@@ -8,21 +8,7 @@ if( peliasConfig.api.accessLog ){
   app.use( require( './middleware/access_log' ).createAccessLogger( peliasConfig.api.accessLog ) );
 }
 
-var swaggerDefinition = {
-  info: { // API informations (required)
-    title: 'Hello World', // Title (required)
-    version: '1.0.0', // Version (required)
-    description: 'A sample API', // Description (optional)
-  },
-  basePath: __dirname, // Base path (optional)
-};
-var options = {
-  // Import swaggerDefinitions
-  swaggerDefinition: swaggerDefinition,
-  // Path to the API docs
-  apis: ['routes/*.js']
-};
-var swaggerSpec = swaggerJSDoc(options);
+var swaggerSpec = swaggerJSDoc(require( './config/swagger'));
 
 
 

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -1,0 +1,13 @@
+const options = { 
+    'swaggerDefinition' : {
+    'info': {
+        'description': 'Swagger documentation for Pelias API',
+        'title': 'Pelias API',
+        'version': '1.0.0'
+    }
+    },
+    'basePath': __dirname,
+    'apis': ['./routes/*.js']
+};
+
+module.exports = options;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "elasticsearch-exceptions": "0.0.4",
     "express": "^4.8.8",
     "express-jwt": "^0.3.1",
+    "express-swaggerize-ui": "^1.0.2",
     "geojson": "^0.5.0",
     "geolib": "^2.0.18",
     "iso-639-3": "^1.0.0",
@@ -68,6 +69,7 @@
     "predicates": "^2.0.0",
     "retry": "^0.10.1",
     "stats-lite": "^2.0.4",
+    "swagger-jsdoc": "^1.9.7",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/public/attribution.md
+++ b/public/attribution.md
@@ -1,8 +1,7 @@
 ## Attribution
-* Geocoding by [Pelias](https://mapzen.com/pelias) from [Mapzen](https://mapzen.com)
+* Geocoding by [Pelias](https://pelias.io).
 * Data from
-   * [OpenStreetMap](http://www.openstreetmap.org/copyright) © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)
-   * [OpenAddresses](http://openaddresses.io) under a [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) public domain designation
-   * [GeoNames](http://www.geonames.org/) under [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)
-   * [WhosOnFirst](http://whosonfirst.mapzen.com) under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)
-   * [Geographic Names Database](http://geonames.nga.mil/gns/html/index.html)
+   * [OpenStreetMap](http://www.openstreetmap.org/copyright) © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/). Also see the [OSM Geocoding Guidelines](https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines/Geocoding_-_Guideline) for acceptable use.
+   * [OpenAddresses](http://openaddresses.io) under [various public-domain and share-alike licenses](http://results.openaddresses.io/)
+   * [GeoNames](http://www.geonames.org/) under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
+   * [WhosOnFirst](https://www.whosonfirst.org/) under [various CC-BY or CC-0 equivalent licenses](https://whosonfirst.org/docs/licenses/)

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -538,7 +538,7 @@ function addRoutes(app, peliasConfig) {
    *     operationId: attribution
    *     produces:
    *       - application/json
-   *     summary: Landing page w/attribution
+   *     summary: landing page w/attribution
    *     responses:
    *       200:
    *         description: 200 ok
@@ -635,7 +635,44 @@ function addRoutes(app, peliasConfig) {
    *         in: query
    *         required: true
    *         type: string
-   * 
+   *       - name: focus.point.lat
+   *         description: Focus point latitude
+   *         in: query
+   *         type: number
+   *       - name: focus.point.lon
+   *         description: Focus point longitude
+   *         in: query
+   *         type: number
+   *       - name: boundary.rect.min_lon
+   *         description: Bounding box minimum longitude
+   *         in: query
+   *         type: number
+   *       - name: boundary.rect.max_lon
+   *         description: Bounding box maximum longitude
+   *         in: query
+   *         type: number
+   *       - name: boundary.rect.min_lat
+   *         description: Bounding box minimum latitude
+   *         in: query
+   *         type: number
+   *       - name: boundary.rect.max_lat
+   *         description: Bounding box maximum latitude
+   *         in: query
+   *         type: number
+   *       - name: sources
+   *         description: Sources
+   *         in: query
+   *         type: string
+   *         enum: [openstreetmap, openaddresses, whosonfirst, geonames]
+   *       - name: layers
+   *         description: Layers
+   *         in: query
+   *         type: string
+   *         enum: [venue, address, street, country, macroregion, region, macrocounty, county, locality, localadmin, borough, neighbourhood, coarse]
+   *       - name: boundary.county
+   *         description: Country boundary
+   *         in: query
+   *         type: string
    *     responses:
    *       200:
    *         description: 200 ok
@@ -665,7 +702,10 @@ function addRoutes(app, peliasConfig) {
    *         in: query
    *         required: true
    *         type: string
-   * 
+   *       - name: size
+   *         description: used to limit the number of results returned.
+   *         in: query
+   *         type: number
    *     responses:
    *       200:
    *         description: 200 ok
@@ -690,7 +730,10 @@ function addRoutes(app, peliasConfig) {
    *         in: query
    *         required: true
    *         type: string
-   * 
+   *       - name: size
+   *         description: used to limit the number of results returned.
+   *         in: query
+   *         type: number
    *     responses:
    *       200:
    *         description: 200 ok
@@ -726,35 +769,35 @@ function addRoutes(app, peliasConfig) {
    *         in: query
    *         type: string
    *       - name: address
-   *         description: Address
+   *         description: can contain a full address with house number or only a street name.
    *         in: query
    *         type: string
    *       - name: neighbourhood
-   *         description: Neighbourhood
+   *         description: vernacular geographic entities that may not necessarily be official administrative divisions but are important nonetheless.
    *         in: query
    *         type: string
    *       - name: borough
-   *         description: Borough
+   *         description: mostly known in the context of New York City, even though they may exist in other cities, such as Mexico City.
    *         in: query
    *         type: string
    *       - name: locality
-   *         description: Locality
+   *         description: equivalent to what are commonly referred to as cities.
    *         in: query
    *         type: string
    *       - name: county
-   *         description: County
+   *         description: administrative divisions between localities and regions.
    *         in: query
    *         type: string
    *       - name: region
-   *         description: Region
+   *         description: the first-level administrative divisions within countries, analogous to states and provinces in the United States and Canada, respectively, though most other countries contain regions as well
    *         in: query
    *         type: string
    *       - name: postalcode
-   *         description: Postal Code
+   *         description: used to aid in sorting mail with the format dictated by an administrative division
    *         in: query
    *         type: string
    *       - name: country
-   *         description: Country
+   *         description: highest-level administrative divisions supported in a search. In addition to full names, countries have common two- and three-letter abbreviations that are also supported values for the country parameter.
    *         in: query
    *         type: string
    *     responses:
@@ -790,6 +833,28 @@ function addRoutes(app, peliasConfig) {
    *         description: Longitude (decimal degrees)
    *         in: query
    *         required: true
+   *         type: string
+   *       - name: boundary.circle.radius
+   *         description: Bounding circle radius
+   *         in: query
+   *         type: number
+   *       - name: size
+   *         description: used to limit the number of results returned.
+   *         in: query
+   *         type: number
+   *       - name: sources
+   *         description: one or more valid source names
+   *         in: query
+   *         type: string
+   *         enum: [openstreetmap, openaddresses, whosonfirst, geonames]
+   *       - name: layers
+   *         description: Layers
+   *         in: query
+   *         type: string
+   *         enum: [venue, address, street, country, macroregion, region, macrocounty, county, locality, localadmin, borough, neighbourhood, coarse]
+   *       - name: boundary.county
+   *         description: Country boundary
+   *         in: query
    *         type: string
    *     responses:
    *       200:

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -420,6 +420,28 @@ function addRoutes(app, peliasConfig) {
   app.get ( '/status', routers.status );
 
   // backend dependent endpoints
+
+  /**
+   * @swagger
+   * /place:
+   *   get:
+   *     operationId: place
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: ids
+   *         description: Specific place ID(s) to query.
+   *         in: query
+   *         required: true
+   *         type: array
+   *         items: {"type":"string", "pattern":"^[A-z]*.:[A-z]*.:[0-9]*$"}
+   * 
+   *     responses:
+   *       200:
+   *         description: 200 response
+   *         schema:
+   *           type: object
+   */
   app.get ( base + 'place', routers.place );
   app.get ( base + 'autocomplete', routers.autocomplete );
   app.get ( base + 'search', authMethod, routers.search );

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -27,7 +27,7 @@ const middleware = {
 };
 
 /** ----------------------- controllers ----------------------- **/
-const controllers = {
+const controllers = { 
   coarse_reverse: require('../controller/coarse_reverse'),
   mdToHTML: require('../controller/markdownToHtml'),
   libpostal: require('../controller/libpostal'),
@@ -543,31 +543,28 @@ function addRoutes(app, peliasConfig) {
    *       200:
    *         description: 200 ok
    *         examples: 
-   *           application/json: {  "markdown": "# Pelias API\n### Version: [1.0]
-   * (https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation 
-   * on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)
-   * \n## Attribution\n* Geocoding by [Pelias](https://mapzen.com/pelias) from [Mapzen]
-   * (https://mapzen.com)\n* Data from\n   * [OpenStreetMap](http://www.openstreetmap.org/copyright)
-   *  © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)\n 
-   *   * [OpenAddresses](http://openaddresses.io) under a 
-   * [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) 
-   * public domain designation\n   * [GeoNames](http://www.geonames.org/) under 
-   * [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)\n   * [WhosOnFirst](http://whosonfirst.mapzen.com) 
-   * under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)\n   
-   * * [Geographic Names Database](http://geonames.nga.mil/gns/html/index.html)\n",  
-   * "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n
-   * <h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n
-   * <h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>
-   * \n\n<h2>Attribution</h2>\n\n<ul><li>Geocoding by <a href=\"https://mapzen.com/pelias\">Pelias</a> from 
-   * <a href=\"https://mapzen.com\">Mapzen</a></li><li>Data from<ul><li><a href=\"http://www.openstreetmap.org/copyright\">
-   * OpenStreetMap</a> © OpenStreetMap contributors under <a href=\"http://opendatacommons.org/licenses/odbl/\">
-   * ODbL</a></li><li><a href=\"http://openaddresses.io\">OpenAddresses</a> under a 
-   * <a href=\"https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE\">Creative Commons Zero</a> 
-   * public domain designation</li><li><a href=\"http://www.geonames.org/\">GeoNames</a> under 
-   * <a href=\"https://creativecommons.org/licenses/by/2.0/\">CC-BY-3.0</a></li><li><a href=\"http://whosonfirst.mapzen.com\">
-   * WhosOnFirst</a>*  under <a href=\"https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md\">various
-   *  licenses</a></li>* <li><a href=\"http://geonames.nga.mil/gns/html/index.html\">Geographic Names Database</a></li></ul>
-   * </li></ul>"}
+   *           application/json: {
+   * "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n
+   * ### [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n
+   * ## Attribution\n* Geocoding by [Pelias](https://pelias.io).\n* Data from\n   * [OpenStreetMap](http://www.openstreetmap.org/copyright)
+   * © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/). Also see the [OSM Geocoding Guidelines]
+   * (https://wiki.osmfoundation.org/wiki/Licence/Community_Guidelines/Geocoding_-_Guideline) for acceptable use.\n   
+   * * [OpenAddresses](http://openaddresses.io) under [various public-domain and share-alike licenses](http://results.openaddresses.io/)\n  
+   * * [GeoNames](http://www.geonames.org/) under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)\n   * [WhosOnFirst]
+   * (https://www.whosonfirst.org/) under [various CC-BY or CC-0 equivalent licenses](https://whosonfirst.org/docs/licenses/)",
+   * "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: 
+   * <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n<h3>
+   * <a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>\n\n
+   * <h2>Attribution</h2>\n\n<ul><li>Geocoding by <a href=\"https://pelias.io\">Pelias</a>.</li><li>Data from<ul><li>
+   * <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> © OpenStreetMap contributors under 
+   * <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>. Also see the <a href=\"https://wiki.osmfoundation.org/wiki/
+   * Licence/Community_Guidelines/Geocoding_-_Guideline\">OSM Geocoding Guidelines</a> for acceptable use.</li><li>
+   * <a href=\"http://openaddresses.io\">OpenAddresses</a> under <a href=\"http://results.openaddresses.io/\">various 
+   * public-domain and share-alike licenses</a></li><li><a href=\"http://www.geonames.org/\">GeoNames</a> under 
+   * <a href=\"https://creativecommons.org/licenses/by/4.0/\">CC-BY-4.0</a></li><li><a href=\"https://www.whosonfirst.org/\">
+   * WhosOnFirst</a> under <a href=\"https://whosonfirst.org/docs/licenses/\">various CC-BY or CC-0 equivalent licenses</a>
+   * </li></ul></li></ul>"
+}
    */
   app.get ( base + 'attribution', routers.attribution );
   app.get ( '/attribution', routers.attribution );
@@ -603,7 +600,7 @@ function addRoutes(app, peliasConfig) {
    *     summary: For querying specific place ID(s)
    *     parameters:
    *       - name: ids
-   *         description: Specific place ID(s) to query.
+   *         description: for details on a place returned from a previous query
    *         in: query
    *         required: true
    *         type: array
@@ -629,7 +626,7 @@ function addRoutes(app, peliasConfig) {
    *     tags: 
    *       - v1
    *     operationId: autocomplete
-   *     summary: Standard text query w/greater flexibility with partial matches and incomplete wording.
+   *     summary: to give real-time result suggestions without having to type the whole location
    *     produces:
    *       - application/json
    *     parameters:
@@ -659,7 +656,32 @@ function addRoutes(app, peliasConfig) {
    *     tags: 
    *       - v1
    *     operationId: search
-   *     summary: Standard text query search.
+   *     summary: to find a place by searching for an address or name
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: text
+   *         description: Text query
+   *         in: query
+   *         required: true
+   *         type: string
+   * 
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   *   post:
+   *     tags: 
+   *       - v1
+   *     operationId: search
+   *     summary: to find a place by searching for an address or name
    *     produces:
    *       - application/json
    *     parameters:
@@ -690,67 +712,7 @@ function addRoutes(app, peliasConfig) {
    *     tags: 
    *       - v1
    *     operationId: structured
-   *     summary: Standard text query with filtering by standard WOF properties.
-   *     produces:
-   *       - application/json
-   *     parameters:
-   *       - name: text
-   *         description: Text query
-   *         in: query
-   *         required: true
-   *         type: string
-   *       - name: venue
-   *         description: WOF Venue
-   *         in: query
-   *         type: string
-   *       - name: address
-   *         description: Address
-   *         in: query
-   *         type: string
-   *       - name: neighbourhood
-   *         description: Neighbourhood
-   *         in: query
-   *         type: string
-   *       - name: borough
-   *         description: Borough
-   *         in: query
-   *         type: string
-   *       - name: locality
-   *         description: Locality
-   *         in: query
-   *         type: string
-   *       - name: county
-   *         description: County
-   *         in: query
-   *         type: string
-   *       - name: region
-   *         description: Region
-   *         in: query
-   *         type: string
-   *       - name: postalcode
-   *         description: Postal Code
-   *         in: query
-   *         type: string
-   *       - name: country
-   *         description: Country
-   *         in: query
-   *         type: string
-   *     responses:
-   *       200:
-   *         description: 200 ok
-   *         schema:
-   *           type: object
-   *           $ref: '#/definitions/standardPeliasReturn'
-   *       400:
-   *         description: 400 bad request
-   *         schema:
-   *           type: object
-   *           $ref: '#/definitions/standardPeliasErrorReturn'
-   *   post:
-   *     tags: 
-   *       - v1
-   *     operationId: structured
-   *     summary: Standard text query with filtering by standard WOF properties.
+   *     summary: to find a place with data already separated into housenumber, street, city, etc.
    *     produces:
    *       - application/json
    *     parameters:
@@ -815,7 +777,7 @@ function addRoutes(app, peliasConfig) {
    *     tags: 
    *       - v1
    *     operationId: reverse
-   *     summary: Reverse geocode search.
+   *     summary: to find what is located at a certain coordinate location
    *     produces:
    *       - application/json
    *     parameters:
@@ -849,7 +811,7 @@ function addRoutes(app, peliasConfig) {
    *     tags: 
    *       - v1 
    *     operationId: nearby
-   *     summary: Reverse geocode search including surrounding areas.
+   *     summary: reverse geocode search including surrounding areas
    *     produces:
    *       - application/json
    *     parameters:
@@ -884,7 +846,7 @@ function addRoutes(app, peliasConfig) {
    *     tags:
    *       - v1
    *     operationId: convert
-   *     summary: Proxy to the MGRS GEOTRANS Conversion service.
+   *     summary: proxy to the MGRS GEOTRANS conversion service
    *     produces:
    *       - application/json
    *     parameters:

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -523,7 +523,11 @@ function addRoutes(app, peliasConfig) {
    *       200:
    *         description: 200 ok
    *         examples: 
-   *           application/json: { "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n", "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n<h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>" }
+   *           application/json: { "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n### 
+   * [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n", "html": "<style>ht
+   * ml{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">
+   * 1.0</a></h3>\n\n<h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation 
+   * on GitHub</a></h3>" }
    */
   app.get ( base, routers.index );
   /**
@@ -540,7 +544,31 @@ function addRoutes(app, peliasConfig) {
    *       200:
    *         description: 200 ok
    *         examples: 
-   *           application/json: {  "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n## Attribution\n* Geocoding by [Pelias](https://mapzen.com/pelias) from [Mapzen](https://mapzen.com)\n* Data from\n   * [OpenStreetMap](http://www.openstreetmap.org/copyright) © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)\n   * [OpenAddresses](http://openaddresses.io) under a [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) public domain designation\n   * [GeoNames](http://www.geonames.org/) under [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)\n   * [WhosOnFirst](http://whosonfirst.mapzen.com) under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)\n   * [Geographic Names Database](http://geonames.nga.mil/gns/html/index.html)\n",  "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n<h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>\n\n<h2>Attribution</h2>\n\n<ul><li>Geocoding by <a href=\"https://mapzen.com/pelias\">Pelias</a> from <a href=\"https://mapzen.com\">Mapzen</a></li><li>Data from<ul><li><a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> © OpenStreetMap contributors under <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a></li><li><a href=\"http://openaddresses.io\">OpenAddresses</a> under a <a href=\"https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE\">Creative Commons Zero</a> public domain designation</li><li><a href=\"http://www.geonames.org/\">GeoNames</a> under <a href=\"https://creativecommons.org/licenses/by/2.0/\">CC-BY-3.0</a></li><li><a href=\"http://whosonfirst.mapzen.com\">WhosOnFirst</a> under <a href=\"https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md\">various licenses</a></li><li><a href=\"http://geonames.nga.mil/gns/html/index.html\">Geographic Names Database</a></li></ul></li></ul>"}
+   *           application/json: {  "markdown": "# Pelias API\n### Version: [1.0]
+   * (https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation 
+   * on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)
+   * \n## Attribution\n* Geocoding by [Pelias](https://mapzen.com/pelias) from [Mapzen]
+   * (https://mapzen.com)\n* Data from\n   * [OpenStreetMap](http://www.openstreetmap.org/copyright)
+   *  © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)\n 
+   *   * [OpenAddresses](http://openaddresses.io) under a 
+   * [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) 
+   * public domain designation\n   * [GeoNames](http://www.geonames.org/) under 
+   * [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)\n   * [WhosOnFirst](http://whosonfirst.mapzen.com) 
+   * under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)\n   
+   * * [Geographic Names Database](http://geonames.nga.mil/gns/html/index.html)\n",  
+   * "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n
+   * <h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n
+   * <h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>
+   * \n\n<h2>Attribution</h2>\n\n<ul><li>Geocoding by <a href=\"https://mapzen.com/pelias\">Pelias</a> from 
+   * <a href=\"https://mapzen.com\">Mapzen</a></li><li>Data from<ul><li><a href=\"http://www.openstreetmap.org/copyright\">
+   * OpenStreetMap</a> © OpenStreetMap contributors under <a href=\"http://opendatacommons.org/licenses/odbl/\">
+   * ODbL</a></li><li><a href=\"http://openaddresses.io\">OpenAddresses</a> under a 
+   * <a href=\"https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE\">Creative Commons Zero</a> 
+   * public domain designation</li><li><a href=\"http://www.geonames.org/\">GeoNames</a> under 
+   * <a href=\"https://creativecommons.org/licenses/by/2.0/\">CC-BY-3.0</a></li><li><a href=\"http://whosonfirst.mapzen.com\">
+   * WhosOnFirst</a>*  under <a href=\"https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md\">various
+   *  licenses</a></li>* <li><a href=\"http://geonames.nga.mil/gns/html/index.html\">Geographic Names Database</a></li></ul>
+   * </li></ul>"}
    */
   app.get ( base + 'attribution', routers.attribution );
   app.get ( '/attribution', routers.attribution );

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -413,21 +413,167 @@ function addRoutes(app, peliasConfig) {
   //Set authorization method based on pelias config
   let authMethod = authService.determineAuth();
 
+
+
+//Models
+/**
+   * @swagger
+   * definitions:
+   *   standardPeliasReturn:
+   *     properties:
+   *       geocoding:
+   *         type: object
+   *         $ref: '#/definitions/geocodingObject'
+   *       type:
+   *         type: string
+   *       features:
+   *         type: array
+   *         items:
+   *           $ref: '#/definitions/featureObject'
+   *       bbox:
+   *         type: array
+   *         items: number
+   *   standardPeliasErrorReturn:
+   *     properties:
+   *       geocoding:
+   *         type: object
+   *         $ref: '#/definitions/geocodingErrorObject'
+   *       type:
+   *         type: string
+   *       features:
+   *         type: array
+   *         items:
+   *           $ref: '#/definitions/featureObject'
+   *       bbox:
+   *         type: array
+   *         items: number
+   *   geocodingObject:
+   *     properties:
+   *       version:
+   *         type: string
+   *       attribution:
+   *         type: string
+   *       query:
+   *         type: object
+   *       engine:
+   *         type: object
+   *       timestamp:
+   *         type: string
+   *   geocodingErrorObject:
+   *     properties:
+   *       version:
+   *         type: string
+   *       attribution:
+   *         type: string
+   *       query:
+   *         type: object
+   *       errors:
+   *         type: array
+   *         items: string
+   *       timestamp:
+   *         type: string
+   *   featureObject:
+   *     properties:
+   *       type:
+   *         type: string
+   *       geometry:
+   *         type: object
+   *       properties:
+   *         type: object
+   *       bbox:
+   *         type: array
+   *         items: number
+   *   convertReturn:
+   *     properties:
+   *       type:
+   *         type: string
+   *       geometry:
+   *         type: object
+   *       properties:
+   *         type: object
+   *         $ref: '#/definitions/convertPropertiesObject'
+   *       bbox:
+   *         type: array
+   *         items: number
+   *   convertPropertiesObject:
+   *     properties:
+   *       from:
+   *         type: string
+   *       to:
+   *         type: string
+   *       name:
+   *         type: string
+   *   convertErrorReturn: 
+   *     properties:
+   *       errors:
+   *         type: string
+*/
   // static data endpoints
+  /**
+   * @swagger
+   * /v1:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: v1
+   *     produces:
+   *       - application/json
+   *     summary: Landing page
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         examples: 
+   *           application/json: { "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n", "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n<h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>" }
+   */
   app.get ( base, routers.index );
+  /**
+   * @swagger
+   * /v1/attribution:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: attribution
+   *     produces:
+   *       - application/json
+   *     summary: Landing page w/attribution
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         examples: 
+   *           application/json: {  "markdown": "# Pelias API\n### Version: [1.0](https://github.com/venicegeo/pelias-api/releases)\n### [View our documentation on GitHub](https://github.com/venicegeo/pelias-documentation/blob/master/README.md)\n## Attribution\n* Geocoding by [Pelias](https://mapzen.com/pelias) from [Mapzen](https://mapzen.com)\n* Data from\n   * [OpenStreetMap](http://www.openstreetmap.org/copyright) © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)\n   * [OpenAddresses](http://openaddresses.io) under a [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) public domain designation\n   * [GeoNames](http://www.geonames.org/) under [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)\n   * [WhosOnFirst](http://whosonfirst.mapzen.com) under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)\n   * [Geographic Names Database](http://geonames.nga.mil/gns/html/index.html)\n",  "html": "<style>html{font-family:monospace}</style><h1>Pelias API</h1>\n\n<h3>Version: <a href=\"https://github.com/venicegeo/pelias-api/releases\">1.0</a></h3>\n\n<h3><a href=\"https://github.com/venicegeo/pelias-documentation/blob/master/README.md\">View our documentation on GitHub</a></h3>\n\n<h2>Attribution</h2>\n\n<ul><li>Geocoding by <a href=\"https://mapzen.com/pelias\">Pelias</a> from <a href=\"https://mapzen.com\">Mapzen</a></li><li>Data from<ul><li><a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> © OpenStreetMap contributors under <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a></li><li><a href=\"http://openaddresses.io\">OpenAddresses</a> under a <a href=\"https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE\">Creative Commons Zero</a> public domain designation</li><li><a href=\"http://www.geonames.org/\">GeoNames</a> under <a href=\"https://creativecommons.org/licenses/by/2.0/\">CC-BY-3.0</a></li><li><a href=\"http://whosonfirst.mapzen.com\">WhosOnFirst</a> under <a href=\"https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md\">various licenses</a></li><li><a href=\"http://geonames.nga.mil/gns/html/index.html\">Geographic Names Database</a></li></ul></li></ul>"}
+   */
   app.get ( base + 'attribution', routers.attribution );
   app.get ( '/attribution', routers.attribution );
+  /**
+   * @swagger
+   * /status:
+   *   get:
+   *     tags: 
+   *       - base
+   *     operationId: attribution
+   *     produces:
+   *       - text/plain
+   *     summary: Landing page w/attribution
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         examples: 
+   *           text/plain: "status: ok"
+   */
   app.get ( '/status', routers.status );
 
   // backend dependent endpoints
 
   /**
    * @swagger
-   * /place:
+   * /v1/place:
    *   get:
+   *     tags: 
+   *       - v1
    *     operationId: place
    *     produces:
    *       - application/json
+   *     summary: For querying specific place ID(s)
    *     parameters:
    *       - name: ids
    *         description: Specific place ID(s) to query.
@@ -438,17 +584,259 @@ function addRoutes(app, peliasConfig) {
    * 
    *     responses:
    *       200:
-   *         description: 200 response
+   *         description: 200 ok
    *         schema:
    *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
    */
   app.get ( base + 'place', routers.place );
+  /**
+   * @swagger
+   * /v1/autocomplete:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: autocomplete
+   *     summary: Standard text query w/greater flexibility with partial matches and incomplete wording.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: text
+   *         description: Text query
+   *         in: query
+   *         required: true
+   *         type: string
+   * 
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   */
   app.get ( base + 'autocomplete', routers.autocomplete );
+  /**
+   * @swagger
+   * /v1/search:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: search
+   *     summary: Standard text query search.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: text
+   *         description: Text query
+   *         in: query
+   *         required: true
+   *         type: string
+   * 
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   */
   app.get ( base + 'search', authMethod, routers.search );
   app.post( base + 'search', authMethod, routers.search );
+  /**
+   * @swagger
+   * /v1/search/structured:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: structured
+   *     summary: Standard text query with filtering by standard WOF properties.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: text
+   *         description: Text query
+   *         in: query
+   *         required: true
+   *         type: string
+   *       - name: venue
+   *         description: WOF Venue
+   *         in: query
+   *         type: string
+   *       - name: address
+   *         description: Address
+   *         in: query
+   *         type: string
+   *       - name: neighbourhood
+   *         description: Neighbourhood
+   *         in: query
+   *         type: string
+   *       - name: borough
+   *         description: Borough
+   *         in: query
+   *         type: string
+   *       - name: locality
+   *         description: Locality
+   *         in: query
+   *         type: string
+   *       - name: county
+   *         description: County
+   *         in: query
+   *         type: string
+   *       - name: region
+   *         description: Region
+   *         in: query
+   *         type: string
+   *       - name: postalcode
+   *         description: Postal Code
+   *         in: query
+   *         type: string
+   *       - name: country
+   *         description: Country
+   *         in: query
+   *         type: string
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   */
   app.get ( base + 'search/structured', authMethod, routers.structured );
+  /**
+   * @swagger
+   * /v1/reverse:
+   *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: reverse
+   *     summary: Reverse geocode search.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: point.lat
+   *         description: Latitude (decimal degrees)
+   *         in: query
+   *         required: true
+   *         type: string
+   *       - name: point.lon
+   *         description: Longitude (decimal degrees)
+   *         in: query
+   *         required: true
+   *         type: string
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   */
   app.get ( base + 'reverse', authMethod, routers.reverse );
+  /**
+   * @swagger
+   * /v1/nearby:
+   *   get:
+   *     tags: 
+   *       - v1 
+   *     operationId: nearby
+   *     summary: Reverse geocode search including surrounding areas.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: point.lat
+   *         description: Latitude (decimal degrees)
+   *         in: query
+   *         required: true
+   *         type: string
+   *       - name: point.lon
+   *         description: Longitude (decimal degrees)
+   *         in: query
+   *         required: true
+   *         type: string
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   * 
+   */
   app.get ( base + 'nearby', routers.nearby );
+  /**
+   * @swagger
+   * /v1/convert:
+   *   get:
+   *     tags:
+   *       - v1
+   *     operationId: convert
+   *     summary: Proxy to the MGRS GEOTRANS Conversion service.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: from
+   *         description: Origin coordinate type
+   *         in: query
+   *         required: true
+   *         type: string
+   *         enum: ["decdeg", "mgrs"]
+   *       - name: to
+   *         description: Destination coordinate type
+   *         in: query
+   *         required: true
+   *         type: string
+   *         enum: ["decdeg", "mgrs"]
+   *       - name: lat
+   *         description: Latitude (decimal degrees) - Required on Decdeg -> MGRS conversion
+   *         in: query
+   *         type: string
+   *       - name: lon
+   *         description: Longitude (decimal degrees) - Required on Decdeg -> MGRS conversion
+   *         in: query
+   *         type: string
+   *       - name: q
+   *         description: MGRS coordinate - Required on MGRS -> Decdeg conversion
+   *         in: query
+   *         type: string
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/convertReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/convertErrorReturn'
+   */
   app.get ( base + 'convert', authMethod, routers.convert );
 }
 /**

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -9,7 +9,6 @@ const Router = require('express').Router,
       peliasConfig = require( 'pelias-config' ).generate(require('../schema')),
       authService = require('../service/auth');
 
-
 /** ----------------------- sanitizers ----------------------- **/
 const sanitizers = {
   autocomplete: require('../sanitizer/autocomplete'),
@@ -28,7 +27,6 @@ const middleware = {
 };
 
 /** ----------------------- controllers ----------------------- **/
-
 const controllers = {
   coarse_reverse: require('../controller/coarse_reverse'),
   mdToHTML: require('../controller/markdownToHtml'),
@@ -42,6 +40,7 @@ const controllers = {
   convert: require('../controller/convert')
 };
 
+/** ----------------------- queries ----------------------- **/
 const queries = {
   cascading_fallback: require('../query/search'),
   very_old_prod: require('../query/search_original'),
@@ -51,8 +50,8 @@ const queries = {
   address_using_ids: require('../query/address_search_using_ids')
 };
 
-/** ----------------------- controllers ----------------------- **/
 
+/** ----------------------- post-processors ----------------------- **/
 const postProc = {
   trimByGranularity: require('../middleware/trimByGranularity'),
   trimByGranularityStructured: require('../middleware/trimByGranularityStructured'),
@@ -508,7 +507,7 @@ function addRoutes(app, peliasConfig) {
    *       errors:
    *         type: string
 */
-  // static data endpoints
+
   /**
    * @swagger
    * /v1:
@@ -688,6 +687,66 @@ function addRoutes(app, peliasConfig) {
    * @swagger
    * /v1/search/structured:
    *   get:
+   *     tags: 
+   *       - v1
+   *     operationId: structured
+   *     summary: Standard text query with filtering by standard WOF properties.
+   *     produces:
+   *       - application/json
+   *     parameters:
+   *       - name: text
+   *         description: Text query
+   *         in: query
+   *         required: true
+   *         type: string
+   *       - name: venue
+   *         description: WOF Venue
+   *         in: query
+   *         type: string
+   *       - name: address
+   *         description: Address
+   *         in: query
+   *         type: string
+   *       - name: neighbourhood
+   *         description: Neighbourhood
+   *         in: query
+   *         type: string
+   *       - name: borough
+   *         description: Borough
+   *         in: query
+   *         type: string
+   *       - name: locality
+   *         description: Locality
+   *         in: query
+   *         type: string
+   *       - name: county
+   *         description: County
+   *         in: query
+   *         type: string
+   *       - name: region
+   *         description: Region
+   *         in: query
+   *         type: string
+   *       - name: postalcode
+   *         description: Postal Code
+   *         in: query
+   *         type: string
+   *       - name: country
+   *         description: Country
+   *         in: query
+   *         type: string
+   *     responses:
+   *       200:
+   *         description: 200 ok
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasReturn'
+   *       400:
+   *         description: 400 bad request
+   *         schema:
+   *           type: object
+   *           $ref: '#/definitions/standardPeliasErrorReturn'
+   *   post:
    *     tags: 
    *       - v1
    *     operationId: structured


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32872347/41052695-7f8a9aa8-6987-11e8-8b04-68385f8e218a.png)

Using [swagger-jsdoc](https://www.npmjs.com/package/swagger-jsdoc) and [express-swaggerize-ui](https://www.npmjs.com/package/express-swaggerize-ui), Swagger documentation is now generated and served upon `npm start`, compiling API information commented inline on `routes/v1.js`.

**URLs**:
* Viewing Swagger UI: `<pelias-api>/api-docs`
* Viewing Swagger JSON document: `<pelias-api>/api-docs.json`

This can be viewed successfully without running the full Pelias dockerfiles suite, however, the _Try it out_ functionality on the Swagger UI may return results inconsistent with that of the examples given.