### PR TITLE
Revert to Addressit

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -32,10 +32,10 @@ const middleware = {
 const controllers = {
   coarse_reverse: require('../controller/coarse_reverse'),
   mdToHTML: require('../controller/markdownToHtml'),
-  libpostal: require('../controller/libpostal'),
-  structured_libpostal: require('../controller/structured_libpostal'),
+  // libpostal: require('../controller/libpostal'),
+  // structured_libpostal: require('../controller/structured_libpostal'),
   place: require('../controller/place'),
-  placeholder: require('../controller/placeholder'),
+  // placeholder: require('../controller/placeholder'),
   search: require('../controller/search'),
   search_with_ids: require('../controller/search_with_ids'),
   status: require('../controller/status'),
@@ -70,7 +70,7 @@ const postProc = {
   parseBoundingBox: require('../middleware/parseBBox'),
   normalizeParentIds: require('../middleware/normalizeParentIds'),
   assignLabels: require('../middleware/assignLabels'),
-  changeLanguage: require('../middleware/changeLanguage'),
+  // changeLanguage: require('../middleware/changeLanguage'),
   sortResponseData: require('../middleware/sortResponseData')
 };
 
@@ -98,11 +98,11 @@ const hasNumberButNotStreet = all(
 );
 
 const serviceWrapper = require('pelias-microservice-wrapper').service;
-const PlaceHolder = require('../service/configurations/PlaceHolder');
+// const PlaceHolder = require('../service/configurations/PlaceHolder');
 const PointInPolygon = require('../service/configurations/PointInPolygon');
 const Language = require('../service/configurations/Language');
 const Interpolation = require('../service/configurations/Interpolation');
-const Libpostal = require('../service/configurations/Libpostal');
+// const Libpostal = require('../service/configurations/Libpostal');
 
 /**
  * Append routes to app
@@ -118,129 +118,129 @@ function addRoutes(app, peliasConfig) {
   const pipService = serviceWrapper(pipConfiguration);
   const isPipServiceEnabled = _.constant(pipConfiguration.isEnabled());
 
-  const placeholderConfiguration = new PlaceHolder(_.defaultTo(peliasConfig.api.services.placeholder, {}));
-  const placeholderService = serviceWrapper(placeholderConfiguration);
-  const isPlaceholderServiceEnabled = _.constant(placeholderConfiguration.isEnabled());
+  // const placeholderConfiguration = new PlaceHolder(_.defaultTo(peliasConfig.api.services.placeholder, {}));
+  // const placeholderService = serviceWrapper(placeholderConfiguration);
+  // const isPlaceholderServiceEnabled = _.constant(placeholderConfiguration.isEnabled());
 
-  const changeLanguageConfiguration = new Language(_.defaultTo(peliasConfig.api.services.placeholder, {}));
-  const changeLanguageService = serviceWrapper(changeLanguageConfiguration);
-  const isChangeLanguageEnabled = _.constant(changeLanguageConfiguration.isEnabled());
+  // const changeLanguageConfiguration = new Language(_.defaultTo(peliasConfig.api.services.placeholder, {}));
+  // const changeLanguageService = serviceWrapper(changeLanguageConfiguration);
+  // const isChangeLanguageEnabled = _.constant(changeLanguageConfiguration.isEnabled());
 
   const interpolationConfiguration = new Interpolation(_.defaultTo(peliasConfig.api.services.interpolation, {}));
   const interpolationService = serviceWrapper(interpolationConfiguration);
   const isInterpolationEnabled = _.constant(interpolationConfiguration.isEnabled());
 
   // standard libpostal should use req.clean.text for the `address` parameter
-  const libpostalConfiguration = new Libpostal(
-    _.defaultTo(peliasConfig.api.services.libpostal, {}),
-    _.property('clean.text'));
-  const libpostalService = serviceWrapper(libpostalConfiguration);
+  // const libpostalConfiguration = new Libpostal(
+  //   _.defaultTo(peliasConfig.api.services.libpostal, {}),
+  //   _.property('clean.text'));
+  // const libpostalService = serviceWrapper(libpostalConfiguration);
 
   // structured libpostal should use req.clean.parsed_text.address for the `address` parameter
-  const structuredLibpostalConfiguration = new Libpostal(
-    _.defaultTo(peliasConfig.api.services.libpostal, {}),
-    _.property('clean.parsed_text.address'));
-  const structuredLibpostalService = serviceWrapper(structuredLibpostalConfiguration);
+  // const structuredLibpostalConfiguration = new Libpostal(
+  //   _.defaultTo(peliasConfig.api.services.libpostal, {}),
+  //   _.property('clean.parsed_text.address'));
+  // const structuredLibpostalService = serviceWrapper(structuredLibpostalConfiguration);
 
   // fallback to coarse reverse when regular reverse didn't return anything
   const coarseReverseShouldExecute = all(
     isPipServiceEnabled, not(hasRequestErrors), not(hasResponseData)
   );
 
-  const libpostalShouldExecute = all(
-    not(hasRequestErrors),
-    not(isRequestSourcesOnlyWhosOnFirst)
-  );
+  // const libpostalShouldExecute = all(
+  //   not(hasRequestErrors),
+  //   not(isRequestSourcesOnlyWhosOnFirst)
+  // );
 
   // for libpostal to execute for structured requests, req.clean.parsed_text.address must exist
-  const structuredLibpostalShouldExecute = all(
-    not(hasRequestErrors),
-    hasParsedTextProperties.all('address')
-  );
+  // const structuredLibpostalShouldExecute = all(
+  //   not(hasRequestErrors),
+  //   hasParsedTextProperties.all('address')
+  // );
 
   // execute placeholder if libpostal only parsed as admin-only and needs to
   //  be geodisambiguated
-  const placeholderGeodisambiguationShouldExecute = all(
-    not(hasResponseDataOrRequestErrors),
-    isPlaceholderServiceEnabled,
-    // check request.clean for several conditions first
-    not(
-      any(
-        // layers only contains venue, address, or street
-        isOnlyNonAdminLayers,
-        // don't geodisambiguate if categories were requested
-        hasRequestCategories
-      )
-    ),
-    any(
-      // only geodisambiguate if libpostal returned only admin areas or libpostal was skipped
-      isAdminOnlyAnalysis,
-      isRequestSourcesOnlyWhosOnFirst
-    )
-  );
+  // const placeholderGeodisambiguationShouldExecute = all(
+  //   not(hasResponseDataOrRequestErrors),
+  //   isPlaceholderServiceEnabled,
+  //   // check request.clean for several conditions first
+  //   not(
+  //     any(
+  //       // layers only contains venue, address, or street
+  //       isOnlyNonAdminLayers,
+  //       // don't geodisambiguate if categories were requested
+  //       hasRequestCategories
+  //     )
+  //   ),
+  //   any(
+  //     // only geodisambiguate if libpostal returned only admin areas or libpostal was skipped
+  //     isAdminOnlyAnalysis,
+  //     isRequestSourcesOnlyWhosOnFirst
+  //   )
+  // );
 
   // execute placeholder if libpostal identified address parts but ids need to
   //  be looked up for admin parts
-  const placeholderIdsLookupShouldExecute = all(
-    not(hasResponseDataOrRequestErrors),
-    isPlaceholderServiceEnabled,
-    // check clean.parsed_text for several conditions that must all be true
-    all(
-      // run placeholder if clean.parsed_text has 'street'
-      hasParsedTextProperties.any('street'),
-      // don't run placeholder if there's a query or category
-      not(hasParsedTextProperties.any('query', 'category')),
-      // run placeholder if there are any adminareas identified
-      hasParsedTextProperties.any('neighbourhood', 'borough', 'city', 'county', 'state', 'country')
-    )
-  );
+  // const placeholderIdsLookupShouldExecute = all(
+  //   not(hasResponseDataOrRequestErrors),
+  //   isPlaceholderServiceEnabled,
+  //   // check clean.parsed_text for several conditions that must all be true
+  //   all(
+  //     // run placeholder if clean.parsed_text has 'street'
+  //     hasParsedTextProperties.any('street'),
+  //     // don't run placeholder if there's a query or category
+  //     not(hasParsedTextProperties.any('query', 'category')),
+  //     // run placeholder if there are any adminareas identified
+  //     hasParsedTextProperties.any('neighbourhood', 'borough', 'city', 'county', 'state', 'country')
+  //   )
+  // );
 
-  const searchWithIdsShouldExecute = all(
-    not(hasRequestErrors),
-    // don't search-with-ids if there's a query or category
-    not(hasParsedTextProperties.any('query', 'category')),
-    // there must be a street
-    hasParsedTextProperties.any('street')
-  );
+  // const searchWithIdsShouldExecute = all(
+  //   not(hasRequestErrors),
+  //   // don't search-with-ids if there's a query or category
+  //   not(hasParsedTextProperties.any('query', 'category')),
+  //   // there must be a street
+  //   hasParsedTextProperties.any('street')
+  // );
 
   // placeholder should have executed, useful for determining whether to actually
   //  fallback or not (don't fallback to old search if the placeholder response
   //  should be honored as is)
-  const placeholderShouldHaveExecuted = any(
-    placeholderGeodisambiguationShouldExecute,
-    placeholderIdsLookupShouldExecute
-  );
+  // const placeholderShouldHaveExecuted = any(
+  //   placeholderGeodisambiguationShouldExecute,
+  //   placeholderIdsLookupShouldExecute
+  // );
 
   // don't execute the cascading fallback query IF placeholder should have executed
   //  that way, if placeholder didn't return anything, don't try to find more things the old way
-  const fallbackQueryShouldExecute = all(
-    not(hasRequestErrors),
-    not(hasResponseData),
-    not(placeholderShouldHaveExecuted)
-  );
+  // const fallbackQueryShouldExecute = all(
+  //   not(hasRequestErrors),
+  //   not(hasResponseData),
+  //   not(placeholderShouldHaveExecuted)
+  // );
 
   // defer to addressit for analysis IF there's no response AND placeholder should not have executed
-  const shouldDeferToAddressIt = all(
-    not(hasRequestErrors),
-    not(hasResponseData),
-    not(placeholderShouldHaveExecuted)
-  );
+  // const shouldDeferToAddressIt = all(
+  //   not(hasRequestErrors),
+  //   not(hasResponseData),
+  //   // not(placeholderShouldHaveExecuted)
+  // );
 
   // call very old prod query if addressit was the parser
-  const oldProdQueryShouldExecute = all(
-    not(hasRequestErrors),
-    isAddressItParse
-  );
+  // const oldProdQueryShouldExecute = all(
+  //   not(hasRequestErrors),
+  //   isAddressItParse
+  // );
 
   // get language adjustments if:
   // - there's a response
   // - theres's a lang parameter in req.clean
-  const changeLanguageShouldExecute = all(
-    hasResponseData,
-    not(hasRequestErrors),
-    isChangeLanguageEnabled,
-    hasRequestParameter('lang')
-  );
+  // const changeLanguageShouldExecute = all(
+  //   hasResponseData,
+  //   not(hasRequestErrors),
+  //   isChangeLanguageEnabled,
+  //   hasRequestParameter('lang')
+  // );
 
   // interpolate if:
   // - there's a number and street
@@ -282,15 +282,17 @@ function addRoutes(app, peliasConfig) {
       sanitizers.search.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.calcSize(),
-      controllers.libpostal(libpostalService, libpostalShouldExecute),
-      controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
-      controllers.placeholder(placeholderService, geometricFiltersDontApply, placeholderIdsLookupShouldExecute),
-      controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
-      // 3rd parameter is which query module to use, use fallback first, then
-      //  use original search strategy if first query didn't return anything
-      controllers.search(peliasConfig.api, esclient, queries.cascading_fallback, fallbackQueryShouldExecute),
-      sanitizers.defer_to_addressit(shouldDeferToAddressIt),
-      controllers.search(peliasConfig.api, esclient, queries.very_old_prod, oldProdQueryShouldExecute),
+      //disable libpostal until a method for returning polygons and other datasets can be implemented
+      // controllers.libpostal(libpostalService, libpostalShouldExecute),
+      // controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
+      // controllers.placeholder(placeholderService, geometricFiltersDontApply, placeholderIdsLookupShouldExecute),
+      // controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
+      // // 3rd parameter is which query module to use, use fallback first, then
+      // //  use original search strategy if first query didn't return anything
+      // controllers.search(peliasConfig.api, esclient, queries.cascading_fallback, fallbackQueryShouldExecute),
+      // sanitizers.defer_to_addressit(shouldDeferToAddressIt),
+      // controllers.search(peliasConfig.api, esclient, queries.very_old_prod, oldProdQueryShouldExecute),
+      controllers.search(peliasConfig.api, esclient, queries.very_old_prod, () => {return true}),
       postProc.trimByGranularity(),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig.api),
@@ -303,7 +305,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON
@@ -312,7 +314,7 @@ function addRoutes(app, peliasConfig) {
       sanitizers.structured_geocoding.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.calcSize(),
-      controllers.structured_libpostal(structuredLibpostalService, structuredLibpostalShouldExecute),
+      // controllers.structured_libpostal(structuredLibpostalService, structuredLibpostalShouldExecute),
       controllers.search(peliasConfig.api, esclient, queries.structured_geocoding, not(hasResponseDataOrRequestErrors)),
       postProc.trimByGranularityStructured(),
       postProc.distances('focus.point.'),
@@ -325,7 +327,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON
@@ -342,7 +344,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON
@@ -363,7 +365,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON
@@ -383,7 +385,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON
@@ -397,7 +399,7 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.parseBoundingBox(),
       postProc.normalizeParentIds(),
-      postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
+      // postProc.changeLanguage(changeLanguageService, changeLanguageShouldExecute),
       postProc.assignLabels(),
       postProc.geocodeJSON(peliasConfig.api, base),
       postProc.sendJSON

--- a/sanitizer/autocomplete.js
+++ b/sanitizer/autocomplete.js
@@ -16,6 +16,7 @@ module.exports.middleware = (_api_pelias_config) => {
       private: require('../sanitizer/_flag_bool')('private', false),
       location_bias: require('../sanitizer/_location_bias')(_api_pelias_config.defaultParameters),
       geo_autocomplete: require('../sanitizer/_geo_autocomplete')(),
+      geometries: require('../sanitizer/_geometries')(),
       boundary_country: require('../sanitizer/_boundary_country')(),
       categories: require('../sanitizer/_categories')(),
       request_language: require('../sanitizer/_request_language')()

--- a/sanitizer/reverse.js
+++ b/sanitizer/reverse.js
@@ -9,6 +9,7 @@ var sanitizeAll = require('../sanitizer/sanitizeAll'),
       sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
       // depends on the layers and sources sanitizers, must be run after them
       sources_and_layers: require('../sanitizer/_sources_and_layers')(),
+      geometries: require('../sanitizer/_geometries')(),
       geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
       size: require('../sanitizer/_size')(/* use defaults*/),
       private: require('../sanitizer/_flag_bool')('private', false),

--- a/sanitizer/structured_geocoding.js
+++ b/sanitizer/structured_geocoding.js
@@ -15,6 +15,7 @@ module.exports.middleware = (_api_pelias_config) => {
         sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
         // depends on the layers and sources sanitizers, must be run after them
         sources_and_layers: require('../sanitizer/_sources_and_layers')(),
+        geometries: require('../sanitizer/_geometries')(),
         private: require('../sanitizer/_flag_bool')('private', false),
         location_bias: require('../sanitizer/_location_bias')(_api_pelias_config.defaultParameters),
         geo_search: require('../sanitizer/_geo_search')(),


### PR DESCRIPTION
This branch removes libpostal and placeholder (and their related features) until those tools work better with sources that aren't WoF.

We will want additional data such as polygons from sources like OSM, but that data is currently not provided via placeholder.  