### PR TITLE
Lock down all data endpoints

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -420,13 +420,13 @@ function addRoutes(app, peliasConfig) {
   app.get ( '/status', routers.status );
 
   // backend dependent endpoints
-  app.get ( base + 'place', routers.place );
-  app.get ( base + 'autocomplete', routers.autocomplete );
+  app.get ( base + 'place', authMethod, routers.place );
+  app.get ( base + 'autocomplete', authMethod, routers.autocomplete );
   app.get ( base + 'search', authMethod, routers.search );
   app.post( base + 'search', authMethod, routers.search );
   app.get ( base + 'search/structured', authMethod, routers.structured );
   app.get ( base + 'reverse', authMethod, routers.reverse );
-  app.get ( base + 'nearby', routers.nearby );
+  app.get ( base + 'nearby', authMethod, routers.nearby );
   app.get ( base + 'convert', authMethod, routers.convert );
 }
 /**


### PR DESCRIPTION
This PR implements the `authMethod` middleware to all dynamic (data-serving) REST routes in Pelias API.

**Implications of this:** `place`, `autocomplete`, and `nearby` are behind the authentication wall in which `search`, `reverse` and `convert` are currently protected.

**To test:** enable `auth` in `pelias.json` under `api { .. }` and attempt to GET on `place`, `autocomplete`, and `nearby` with and without `Bearer {token}` in POSTman.