### PR TITLE
Swagger Doc Authentication

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -4,7 +4,18 @@ const options = {
         'description': 'Swagger documentation for Pelias API',
         'title': 'Pelias API',
         'version': '1.0.0'
-    }
+    },
+    'schemes': ['http','https'],
+    'securityDefinitions': { 
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        }
+    },
+    'security': [
+       { 'Bearer': []} 
+    ]
     },
     'basePath': __dirname,
     'apis': ['./routes/*.js']

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -7,14 +7,14 @@ const options = {
     },
     'schemes': ['http','https'],
     'securityDefinitions': { 
-        'Bearer': {
+        'JWT': {
             'type': 'apiKey',
             'name': 'Authorization',
             'in': 'header'
         }
     },
     'security': [
-       { 'Bearer': []} 
+       { 'JWT': []} 
     ]
     },
     'basePath': __dirname,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/32872347/41427241-4d1a33f0-6fd4-11e8-8186-2a0d5c58c8bc.png)


Adds support for JWT authentication by allowing the user to enter in a value for `Authorization` in request headers.

**To test:** Enable `jwt` or `geoaxis_jwt` under `auth` key in `pelias.json` and verify that not using "Authentication" function button returns `missing token` and verify that adding `Bearer <token>` in Swagger 2.0 Authentication dialog results in valid results.