### PR TITLE
Read Public Key File for JWT Auth

### DIFF
--- a/service/auth.js
+++ b/service/auth.js
@@ -2,7 +2,8 @@
 
 const jwtChecker = require('express-jwt'),
     peliasConfig = require( 'pelias-config' ).generate(require('../schema')),
-    jwt = require('jsonwebtoken');
+    jwt = require('jsonwebtoken'),
+    fs = require('fs');
     
 /**
  * Reads configuration's API 'auth' key and determines auth method if any
@@ -11,9 +12,10 @@ const jwtChecker = require('express-jwt'),
  */
 
 function determineAuth() {  
+  
     if (peliasConfig.api.auth === 'jwt') {
       return jwtChecker({
-        secret: process.env.JWT_SECRET
+        secret: fs.readFileSync(process.env.PUBLIC_KEY_PATH)
       });
     }
     else if(peliasConfig.api.auth === 'geoaxis_jwt') {

--- a/test/unit/service/auth.js
+++ b/test/unit/service/auth.js
@@ -1,4 +1,5 @@
-const proxyquire = require('proxyquire').noCallThru();
+const proxyquire = require('proxyquire').noCallThru(),
+      fs = require('fs');
 
 let testConfig = {
     'secret': 'Pelias JWT test',
@@ -35,7 +36,10 @@ module.exports.tests.functionality = (test, common) => {
           'headers': {
           }
         };
-      process.env.PUBLIC_KEY_PATH = './pk.pub';
+      let wstream = fs.createWriteStream('tmp.pub');
+      wstream.write('test');
+      wstream.end();
+      process.env.PUBLIC_KEY_PATH = './tmp.pub';
       let service = proxyquire('../../../service/auth', {
         'logger': {
           get: (section) => {

--- a/test/unit/service/auth.js
+++ b/test/unit/service/auth.js
@@ -35,9 +35,7 @@ module.exports.tests.functionality = (test, common) => {
           'headers': {
           }
         };
-      process.env.JWT_SECRET = 'a';
-      process.env.JWT_AUDIENCE = 'a';
-      process.env.JWT_ISSUER = 'a';
+      process.env.PUBLIC_KEY_PATH = './pk.pub';
       let service = proxyquire('../../../service/auth', {
         'logger': {
           get: (section) => {


### PR DESCRIPTION
Changed environmental variable from `JWT_SECRET` to `PUBLIC_KEY_PATH` so as to more accurately describe the use case in which JWT authentication will be implemented.

- This the cert to be in an appropriately-formatted file.
- This does not check for distinguished name, but rather simply performs validation as per official JWT spec.

Unit tests for passing/failing validation are a WIP since a temporary public key file must be written in order to adequately test file buffer logic.

**Potential changes on deployment:** A public key file needs to be added to the file system in the build pipeline or in the Gitlab artifacts.