### PR TITLE
Make basePath configurable

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -8,7 +8,6 @@ const options = {
             'title': 'Pelias API',
             'version': '1.0.0'
         },
-        'schemes': ['http','https'],
         'securityDefinitions': {
             'JWT': {
                 'type': 'apiKey',

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -1,23 +1,26 @@
-const options = { 
+const peliasConfig = require('pelias-config').generate(require('../schema'));
+
+const options = {
     'swaggerDefinition' : {
-    'info': {
-        'description': 'Swagger documentation for Pelias API',
-        'title': 'Pelias API',
-        'version': '1.0.0'
+        'basePath': peliasConfig.api.basePath,
+        'info': {
+            'description': 'Swagger documentation for Pelias API',
+            'title': 'Pelias API',
+            'version': '1.0.0'
+        },
+        'schemes': ['http','https'],
+        'securityDefinitions': {
+            'JWT': {
+                'type': 'apiKey',
+                'name': 'Authorization',
+                'in': 'header'
+            }
+        },
+        'security': [
+        { 'JWT': []}
+        ]
     },
-    'schemes': ['http','https'],
-    'securityDefinitions': { 
-        'JWT': {
-            'type': 'apiKey',
-            'name': 'Authorization',
-            'in': 'header'
-        }
-    },
-    'security': [
-       { 'JWT': []} 
-    ]
-    },
-    'basePath': __dirname,
+
     'apis': ['./routes/*.js']
 };
 

--- a/schema.js
+++ b/schema.js
@@ -16,6 +16,7 @@ module.exports = Joi.object().keys({
   api: Joi.object().required().keys({
     version: Joi.string(),
     indexName: Joi.string(),
+    basePath: Joi.string(),
     host: Joi.string(),
     accessLog: Joi.string().allow(''),
     relativeScores: Joi.boolean(),

--- a/test/unit/helper/fieldValue.js
+++ b/test/unit/helper/fieldValue.js
@@ -26,7 +26,7 @@ module.exports.tests.getArrayValue = function(test) {
     t.deepEqual(field.getArrayValue('foo'), ['foo'], 'string');
     t.deepEqual(field.getArrayValue(['foo','bar']), ['foo','bar'], 'array');
     t.deepEqual(field.getArrayValue(['']), [''], 'array with empty string');
-    t.deepEqual(field.getArrayValue(-0), [0], 'number');
+    t.deepEqual(field.getArrayValue(-0), [-0], 'number');
     t.deepEqual(field.getArrayValue(+0), [0], 'number');
     t.deepEqual(field.getArrayValue({foo: 'bar'}), [{foo: 'bar'}], '[*]');
     t.end();


### PR DESCRIPTION
This PR will allow us to make the basePath configurable so that the Swagger documentation for our API points to the right URLs when you're trying out the API endpoints.